### PR TITLE
Only cast panel data if it has changed since the previous frame.

### DIFF
--- a/FlipDot/Panel.pde
+++ b/FlipDot/Panel.pde
@@ -15,7 +15,8 @@ class Panel {
   int x;
   int y;
   byte[] buffer = new byte[28];
-    
+  boolean has_changed = true;
+
   // Create new panel
   Panel(int adapterId, int panelNum, int offsetX, int offsetY) {
     adapter = adapterId;
@@ -30,17 +31,24 @@ class Panel {
   // Process this panels frame data
   void process() {
     int offset = y * config_canvasW + x;
+    has_changed = false;
     
     // Loop columns in panel
     for (int col = 0; col < 28; col++) {
       byte b = (byte)0x00;
       int index = offset + col;
       
+      // Process each panel column
       for (int panel_row = 0; panel_row < 7; panel_row++) {
         int pixelLocationY = index + (panel_row * config_canvasW);
         if (brightness(virtualDisplay.pixels[pixelLocationY]) > 0.5) {
           b |= 1 << panel_row;
         }
+      }
+
+      // Has something changed?
+      if (b != buffer[col]) {
+        has_changed = true;
       }
       buffer[col] = b;
     }

--- a/FlipDot/cast.pde
+++ b/FlipDot/cast.pde
@@ -52,8 +52,8 @@ void cast_broadcast() {
       // Is this panel connected to this adapter
       if (panels[i].adapter != adapter) continue;
 
-      // Only cast if panels data has changed
-      // @TODO
+      // If enabled and panel image has not changed, skip
+      if (config_cast_only_changed && panels[i].has_changed == false) continue;
 
       // Send frame data
       cast_write(adapter, 0x80);

--- a/FlipDot/config.pde
+++ b/FlipDot/config.pde
@@ -42,6 +42,9 @@
  *   Enable this setting to only cast panel data if its image has changed.
  *   This will save network bandwidth and is ideal for slow networks and/or large displays.
  *   But keep in mind each frame will cast a different amount of data, which could lead to varying frame rates.
+ *
+ * Boolean config_simulate_changes
+ *   Enable if you wish to see the changed panels in the simulator.
  */
 boolean config_cast = false;
 int config_fps = 30;
@@ -50,6 +53,7 @@ int config_canvasH;
 boolean config_video_sync = true;
 boolean config_show_simulator = true;
 boolean config_cast_only_changed = false;
+boolean config_simulate_changes = false;
 
 // Network settings
 //   1 = ETH network

--- a/FlipDot/config.pde
+++ b/FlipDot/config.pde
@@ -37,6 +37,11 @@
  *
  * Boolean config_show_simulator
  *   Show/Hide the UI simulator.
+ *
+ * Boolean config_cast_only_changed
+ *   Enable this setting to only cast panel data if its image has changed.
+ *   This will save network bandwidth and is ideal for slow networks and/or large displays.
+ *   But keep in mind each frame will cast a different amount of data, which could lead to varying frame rates.
  */
 boolean config_cast = false;
 int config_fps = 30;
@@ -44,6 +49,7 @@ int config_canvasW;
 int config_canvasH;
 boolean config_video_sync = true;
 boolean config_show_simulator = true;
+boolean config_cast_only_changed = false;
 
 // Network settings
 //   1 = ETH network

--- a/FlipDot/ui.pde
+++ b/FlipDot/ui.pde
@@ -103,8 +103,6 @@ void ui_simulate() {
     translate(panels[i].x * ui_dot_size, panels[i].y * ui_dot_size);
     
     fill(0);
-    stroke(255, 0, 0);
-    strokeWeight(1);
     noStroke();
     rect(0, 0, 28 * ui_dot_size, 7 * ui_dot_size);
     

--- a/FlipDot/ui.pde
+++ b/FlipDot/ui.pde
@@ -103,7 +103,12 @@ void ui_simulate() {
     translate(panels[i].x * ui_dot_size, panels[i].y * ui_dot_size);
     
     fill(0);
-    noStroke();
+    if (config_simulate_changes && panels[i].has_changed) {
+      stroke(255, 0, 0);
+      strokeWeight(1);
+    } else {
+      noStroke();
+    }
     rect(0, 0, 28 * ui_dot_size, 7 * ui_dot_size);
     
     for (int col = 0; col < 28; col++) {
@@ -113,7 +118,6 @@ void ui_simulate() {
         circle(col * ui_dot_size, row * ui_dot_size, ui_dot_size - 2);
       }
     }
-    
     pop();
   }
   pop();


### PR DESCRIPTION
Boolean config_cast_only_changed
This new setting allows you to only cast a panel's data over the network if it has changed.
This will save network bandwidth and is ideal for slow networks and/or large displays.
But keep in mind each frame will cast a different amount of data, which could lead to varying frame rates.